### PR TITLE
Allow distinction between send and recv delimiters

### DIFF
--- a/ATParser.cpp
+++ b/ATParser.cpp
@@ -178,8 +178,8 @@ bool ATParser::vsend(const char *command, va_list args)
     }
 
     // Finish with newline
-    for (int i = 0; _delimiter[i]; i++) {
-        if (putc(_delimiter[i]) < 0) {
+    for (int i = 0; _send_delimiter[i]; i++) {
+        if (putc(_send_delimiter[i]) < 0) {
             return false;
         }
     }
@@ -201,7 +201,7 @@ vrecv_start:
         int offset = 0;
 
         while (response[i]) {
-            if (memcmp(&response[i+1-_delim_size], _delimiter, _delim_size) == 0) {
+            if (memcmp(&response[i+1-_recv_delim_size], _recv_delimiter, _recv_delim_size) == 0) {
                 i++;
                 break;
             } else if (response[i] == '%' && response[i+1] != '%' && response[i+1] != '*') {
@@ -275,7 +275,7 @@ vrecv_start:
             // Clear the buffer when we hit a newline or ran out of space
             // running out of space usually means we ran into binary data
             if (j+1 >= _buffer_size - offset ||
-                strcmp(&_buffer[offset + j-_delim_size], _delimiter) == 0) {
+                strcmp(&_buffer[offset + j-_recv_delim_size], _recv_delimiter) == 0) {
 
                 debug_if(dbg_on, "AT< %s", _buffer+offset);
                 j = 0;

--- a/ATParser.h
+++ b/ATParser.h
@@ -54,8 +54,10 @@ private:
     int _timeout;
 
     // Parsing information
-    const char *_delimiter;
-    int _delim_size;
+    const char *_recv_delimiter;
+    const char *_send_delimiter;
+    int _recv_delim_size;
+    int _send_delim_size;
     bool dbg_on;
 
     struct oob {
@@ -66,6 +68,25 @@ private:
     std::vector<oob> _oobs;
 
 public:
+    /**
+    * Constructor
+    *
+    * @param serial serial interface to use for AT commands
+    * @param buffer_size size of internal buffer for transaction
+    * @param timeout timeout of the connection
+    * @param send_delimiter string of characters to use as line delimiters for sending
+    * @param recv_delimiter string of characters to use as line delimiters for receiving
+    */
+    ATParser(BufferedSerial &serial, const char *recv_delimiter, const char *send_delimiter, int buffer_size = 256, int timeout = 8000, bool debug = false) :
+        _serial(&serial),
+        _buffer_size(buffer_size) {
+        _buffer = new char[buffer_size];
+        setTimeout(timeout);
+        setRecvDelimiter(recv_delimiter);
+        setSendDelimiter(send_delimiter);
+        debugOn(debug);
+    }
+
     /**
     * Constructor
     *
@@ -105,10 +126,32 @@ public:
     * @param delimiter string of characters to use as line delimiters
     */
     void setDelimiter(const char *delimiter) {
-        _delimiter = delimiter;
-        _delim_size = strlen(delimiter);
+        _recv_delimiter = delimiter;
+        _send_delimiter = delimiter;
+        _recv_delim_size = strlen(delimiter);
+        _send_delim_size = strlen(delimiter);
     }
-    
+
+    /**
+    * Sets string of characters to use as line delimiters for receiving
+    *
+    * @param delimiter string of characters to use as line delimiters
+    */
+    void setRecvDelimiter(const char *delimiter) {
+        _recv_delimiter = delimiter;
+        _recv_delim_size = strlen(delimiter);
+    }
+
+    /**
+    * Sets string of characters to use as line delimiters for sending
+    *
+    * @param delimiter string of characters to use as line delimiters
+    */
+    void setSendDelimiter(const char *delimiter) {
+        _send_delimiter = delimiter;
+        _send_delim_size = strlen(delimiter);
+    }
+
     /**
     * Allows echo to be on or off
     *
@@ -206,7 +249,7 @@ public:
 
     /**
     * Attach a callback for out-of-band data
-    * 
+    *
     * @param prefix string on when to initiate callback
     * @param func callback to call when string is read
     * @note out-of-band data is only processed during a scanf call


### PR DESCRIPTION
The mxchip EMW3080 is being ported to NSAPI (https://github.com/lizhibo32/mxchip-wifi-driver). This chip firmware requires '\r\n' to delimit AT commands sent to the radio, but the responses from the radio are delimited by only '\r'. This behavior is not supported by the current AT command parser. This PR adds support for this behavior. 