### PR TITLE
Add getTimeout() call to ATParser. Add payload for RX callback in BufferedSerial.

### DIFF
--- a/ATParser.h
+++ b/ATParser.h
@@ -100,6 +100,13 @@ public:
     }
 
     /**
+    * Retrieve the timeout between commands
+    */
+    int getTimeout() {
+        return _timeout;
+    }
+
+    /**
     * Sets string of characters to use as line delimiters
     *
     * @param delimiter string of characters to use as line delimiters
@@ -108,7 +115,7 @@ public:
         _delimiter = delimiter;
         _delim_size = strlen(delimiter);
     }
-    
+
     /**
     * Allows echo to be on or off
     *
@@ -206,7 +213,7 @@ public:
 
     /**
     * Attach a callback for out-of-band data
-    * 
+    *
     * @param prefix string on when to initiate callback
     * @param func callback to call when string is read
     * @note out-of-band data is only processed during a scanf call
@@ -230,5 +237,6 @@ public:
     * Flushes the underlying stream
     */
     void flush();
+
 };
 #endif

--- a/BufferedSerial/Buffer/MyBuffer.cpp
+++ b/BufferedSerial/Buffer/MyBuffer.cpp
@@ -4,7 +4,7 @@
  * @brief   Software Buffer - Templated Ring Buffer for most data types
  * @author  sam grove
  * @version 1.0
- * @see     
+ * @see
  *
  * Copyright (c) 2013
  *
@@ -20,7 +20,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 #include "MyBuffer.h"
 
 template <class T>
@@ -29,7 +29,7 @@ MyBuffer<T>::MyBuffer(uint32_t size)
     _buf = new T [size];
     _size = size;
     clear();
-    
+
     return;
 }
 
@@ -37,14 +37,14 @@ template <class T>
 MyBuffer<T>::~MyBuffer()
 {
     delete [] _buf;
-    
+
     return;
 }
 
 template <class T>
-uint32_t MyBuffer<T>::getSize() 
-{ 
-    return this->_size; 
+uint32_t MyBuffer<T>::getSize()
+{
+    return this->_size;
 }
 
 template <class T>
@@ -53,7 +53,7 @@ void MyBuffer<T>::clear(void)
     _wloc = 0;
     _rloc = 0;
     memset(_buf, 0, _size);
-    
+
     return;
 }
 

--- a/BufferedSerial/Buffer/MyBuffer.h
+++ b/BufferedSerial/Buffer/MyBuffer.h
@@ -4,7 +4,7 @@
  * @brief   Software Buffer - Templated Ring Buffer for most data types
  * @author  sam grove
  * @version 1.0
- * @see     
+ * @see
  *
  * Copyright (c) 2013
  *
@@ -20,7 +20,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 #ifndef MYBUFFER_H
 #define MYBUFFER_H
 
@@ -47,7 +47,7 @@
  *      int pos = 0;
  *
  *      while(buf.available())
- *      {   
+ *      {
  *          whats_in_there[pos++] = buf;
  *      }
  *      printf("%c %c\n", whats_in_there[0], whats_in_there[1]);
@@ -71,40 +71,40 @@ public:
      *  @param size The size of the buffer
      */
     MyBuffer(uint32_t size = 0x100);
-    
+
     /** Get the size of the ring buffer
      * @return the size of the ring buffer
      */
      uint32_t getSize();
-    
+
     /** Destry a Buffer and release it's allocated memory
      */
     ~MyBuffer();
-    
+
     /** Add a data element into the buffer
      *  @param data Something to add to the buffer
      */
     void put(T data);
-    
+
     /** Remove a data element from the buffer
      *  @return Pull the oldest element from the buffer
      */
     T get(void);
-    
+
     /** Get the address to the head of the buffer
      *  @return The address of element 0 in the buffer
      */
     T *head(void);
-    
+
     /** Reset the buffer to 0. Useful if using head() to parse packeted data
      */
     void clear(void);
-    
+
     /** Determine if anything is readable in the buffer
      *  @return 1 if something can be read, 0 otherwise
      */
     uint32_t available(void);
-    
+
     /** Overloaded operator for writing to the buffer
      *  @param data Something to put in the buffer
      *  @return
@@ -114,17 +114,17 @@ public:
         put(data);
         return *this;
     }
-    
+
     /** Overloaded operator for reading from the buffer
-     *  @return Pull the oldest element from the buffer 
-     */  
+     *  @return Pull the oldest element from the buffer
+     */
     operator int(void)
     {
         return get();
     }
-    
+
      uint32_t peek(char c);
-    
+
 };
 
 template <class T>
@@ -132,7 +132,7 @@ inline void MyBuffer<T>::put(T data)
 {
     _buf[_wloc++] = data;
     _wloc %= (_size-1);
-    
+
     return;
 }
 
@@ -141,7 +141,7 @@ inline T MyBuffer<T>::get(void)
 {
     T data_pos = _buf[_rloc++];
     _rloc %= (_size-1);
-    
+
     return data_pos;
 }
 
@@ -149,7 +149,7 @@ template <class T>
 inline T *MyBuffer<T>::head(void)
 {
     T *data_pos = &_buf[0];
-    
+
     return data_pos;
 }
 

--- a/BufferedSerial/BufferedSerial.h
+++ b/BufferedSerial/BufferedSerial.h
@@ -4,7 +4,7 @@
  * @brief   Software Buffer - Extends mbed Serial functionallity adding irq driven TX and RX
  * @author  sam grove
  * @version 1.0
- * @see     
+ * @see
  *
  * Copyright (c) 2013
  *
@@ -23,7 +23,7 @@
 
 #ifndef BUFFEREDSERIAL_H
 #define BUFFEREDSERIAL_H
- 
+
 #include "mbed.h"
 #include "MyBuffer.h"
 
@@ -40,22 +40,22 @@
  *  BufferedSerial pc(USBTX, USBRX);
  *
  *  int main()
- *  { 
+ *  {
  *      while(1)
  *      {
  *          Timer s;
- *        
+ *
  *          s.start();
  *          pc.printf("Hello World - buffered\n");
  *          int buffered_time = s.read_us();
  *          wait(0.1f); // give time for the buffer to empty
- *        
+ *
  *          s.reset();
  *          printf("Hello World - blocking\n");
  *          int polled_time = s.read_us();
  *          s.stop();
  *          wait(0.1f); // give time for the buffer to empty
- *        
+ *
  *          pc.printf("printf buffered took %d us\n", buffered_time);
  *          pc.printf("printf blocking took %d us\n", polled_time);
  *          wait(0.5f);
@@ -67,21 +67,21 @@
 /**
  *  @class BufferedSerial
  *  @brief Software buffers and interrupt driven tx and rx for Serial
- */  
-class BufferedSerial : public RawSerial 
+ */
+class BufferedSerial : public RawSerial
 {
 private:
     MyBuffer <char> _rxbuf;
     MyBuffer <char> _txbuf;
     uint32_t      _buf_size;
     uint32_t      _tx_multiple;
- 
+
     void rxIrq(void);
     void txIrq(void);
     void prime(void);
 
-    Callback<void()> _cbs[2];
-    
+    Callback<void(int)> _cbs[2];
+
 public:
     /** Create a BufferedSerial port, connected to the specified transmit and receive pins
      *  @param tx Transmit pin
@@ -92,45 +92,45 @@ public:
      *  @note Either tx or rx may be specified as NC if unused
      */
     BufferedSerial(PinName tx, PinName rx, uint32_t buf_size = 256, uint32_t tx_multiple = 4,const char* name=NULL);
-    
+
     /** Destroy a BufferedSerial port
      */
     virtual ~BufferedSerial(void);
-    
+
     /** Check on how many bytes are in the rx buffer
      *  @return 1 if something exists, 0 otherwise
      */
     virtual int readable(void);
-    
+
     /** Check to see if the tx buffer has room
      *  @return 1 always has room and can overwrite previous content if too small / slow
      */
     virtual int writeable(void);
-    
+
     /** Get a single byte from the BufferedSerial Port.
      *  Should check readable() before calling this.
      *  @return A byte that came in on the Serial Port
      */
     virtual int getc(void);
-    
+
     /** Write a single byte to the BufferedSerial Port.
      *  @param c The byte to write to the Serial Port
      *  @return The byte that was written to the Serial Port Buffer
      */
     virtual int putc(int c);
-    
+
     /** Write a string to the BufferedSerial Port. Must be NULL terminated
      *  @param s The string to write to the Serial Port
      *  @return The number of bytes written to the Serial Port Buffer
      */
     virtual int puts(const char *s);
-    
+
     /** Write a formatted string to the BufferedSerial Port.
      *  @param format The string + format specifiers to write to the Serial Port
      *  @return The number of bytes written to the Serial Port Buffer
      */
     virtual int printf(const char* format, ...);
-    
+
     /** Write data to the Buffered Serial Port
      *  @param s A pointer to data to send
      *  @param length The amount of data being pointed to
@@ -142,7 +142,7 @@ public:
      *  @param func A pointer to a void function, or 0 to set as none
      *  @param type Which serial interrupt to attach the member function to (Serial::RxIrq for receive, TxIrq for transmit buffer empty)
      */
-    virtual void attach(Callback<void()> func, IrqType type=RxIrq);
+    virtual void attach(Callback<void(int)> func, IrqType type=RxIrq);
 
     /** Attach a member function to call whenever a serial interrupt is generated
      *  @param obj pointer to the object to call the member function on
@@ -150,8 +150,8 @@ public:
      *  @param type Which serial interrupt to attach the member function to (Serial::RxIrq for receive, TxIrq for transmit buffer empty)
      */
     template <typename T>
-    void attach(T *obj, void (T::*method)(), IrqType type=RxIrq) {
-        attach(Callback<void()>(obj, method), type);
+    void attach(T *obj, void (T::*method)(int), IrqType type=RxIrq) {
+        attach(Callback<void(int)>(obj, method), type);
     }
 
     /** Attach a member function to call whenever a serial interrupt is generated
@@ -160,8 +160,8 @@ public:
      *  @param type Which serial interrupt to attach the member function to (Serial::RxIrq for receive, TxIrq for transmit buffer empty)
      */
     template <typename T>
-    void attach(T *obj, void (*method)(T*), IrqType type=RxIrq) {
-        attach(Callback<void()>(obj, method), type);
+    void attach(T *obj, void (*method)(T*, int), IrqType type=RxIrq) {
+        attach(Callback<void(int)>(obj, method), type);
     }
 };
 


### PR DESCRIPTION
Because the way the ringbuffer works it's not possible to get the underlying buffer in the RX IRQ callback because then ATParser will miss characters. By adding the character as a parameter to the RX callback you can get the data in the callback, and ATParser will not miss anything (because you can implement another independent buffer).

@geky @sarahmarshy 