### PR TITLE
Fix negative indices in check for delimiter

### DIFF
--- a/ATParser.cpp
+++ b/ATParser.cpp
@@ -201,8 +201,8 @@ vrecv_start:
         int offset = 0;
 
         while (response[i]) {
-            if (memcmp(&response[i+1-_recv_delim_size], _recv_delimiter, _recv_delim_size) == 0) {
-                i++;
+            if (strncmp(&response[i], _recv_delimiter, _recv_delim_size) == 0) {
+                i += _recv_delim_size;
                 break;
             } else if (response[i] == '%' && response[i+1] != '%' && response[i+1] != '*') {
                 _buffer[offset++] = '%';


### PR DESCRIPTION
The check for delimiters was doing something creative in ATParser::recv. Ended up with a negative index. Should be able to replace with strncmp, although this may change the behaviour slightly. Will need to test.

cc @soramame21
related issue https://github.com/ARMmbed/ATParser/issues/12