### PR TITLE
Add process_oob for oob processing

### DIFF
--- a/ATParser.cpp
+++ b/ATParser.cpp
@@ -334,3 +334,41 @@ void ATParser::oob(const char *prefix, Callback<void()> cb)
     oob.cb = cb;
     _oobs.push_back(oob);
 }
+
+bool ATParser::process_oob()
+{
+    if (!_serial->readable()) {
+        return false;
+    }
+
+    int i = 0;
+    while (true) {
+        // Receive next character
+        int c = getc();
+        if (c < 0) {
+            return false;
+        }
+        _buffer[i++] = c;
+        _buffer[i] = 0;
+
+        // Check for oob data
+        for (unsigned int j = 0; j < _oobs.size(); j++) {
+            if (i == (int)_oobs[j].len && memcmp(
+                    _oobs[j].prefix, _buffer, _oobs[j].len) == 0) {
+                debug_if(dbg_on, "AT! %s\r\n", _oobs[j].prefix);
+                _oobs[j].cb();
+                return true;
+            }
+        }
+
+        // Clear the buffer when we hit a newline or ran out of space
+        // running out of space usually means we ran into binary data
+        if (i+1 >= _buffer_size ||
+            strcmp(&_buffer[i-_recv_delim_size], _recv_delimiter) == 0) {
+
+            debug_if(dbg_on, "AT< %s", _buffer);
+            i = 0;
+        }
+    }
+
+}

--- a/ATParser.h
+++ b/ATParser.h
@@ -257,6 +257,16 @@ public:
     void oob(const char *prefix, mbed::Callback<void()> func);
 
     /**
+    * Process out-of-band data
+    *
+    * Process out-of-band data in the receive buffer. This function
+    * returns immediately if there is no data to process.
+    *
+    * @return true if oob data processed, false otherwise
+    */
+    bool process_oob(void);
+
+    /**
     * Attach a callback for out-of-band data
     *
     * @param prefix string on when to initiate callback


### PR DESCRIPTION
This patch adds the function process_oob() which process out of band data if there is any. If there is no data this function returns immediately.