### PR TITLE
Insert compiler optimization barriers

### DIFF
--- a/BufferedSerial/Buffer/MyBuffer.h
+++ b/BufferedSerial/Buffer/MyBuffer.h
@@ -27,6 +27,8 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "cmsis.h"
+
 /** A templated software ring buffer
  *
  * Example:
@@ -130,8 +132,9 @@ public:
 template <class T>
 inline void MyBuffer<T>::put(T data)
 {
-    _buf[_wloc++] = data;
-    _wloc %= (_size-1);
+    _buf[_wloc] = data;
+    __DSB();
+    _wloc = (_wloc + 1) % (_size-1);
     
     return;
 }
@@ -139,8 +142,9 @@ inline void MyBuffer<T>::put(T data)
 template <class T>
 inline T MyBuffer<T>::get(void)
 {
-    T data_pos = _buf[_rloc++];
-    _rloc %= (_size-1);
+    T data_pos = _buf[_rloc];
+    __DSB();
+    _rloc = (_rloc + 1) % (_size-1);
     
     return data_pos;
 }


### PR DESCRIPTION
Insert compiler optimization barriers into methods MyBuffer::put() & MyBuffer::get()

This modification is required to force the compiler to increment the read/write location pointers _rloc and _wloc only after having read/written the data from/to the buffer.
This happened on my side on a NUCLEO_F401RE + X-NUCLEO-IDW01M1 using GCC_ARM toolchain (version 6.3.1 20170620 (release)).

cc @geky